### PR TITLE
Change railtie to load after Rack::Runtime and updated Rack dependency version

### DIFF
--- a/lib/rack/secure_samesite_cookies/railtie.rb
+++ b/lib/rack/secure_samesite_cookies/railtie.rb
@@ -2,7 +2,7 @@ module Rack
   class SecureSamesiteCookies
     class Railtie < ::Rails::Railtie
       initializer "rack-secure_samesite_cookies.configure_rails_initialization" do |app|
-        app.config.middleware.insert_after(ActionDispatch::Static, Rack::SecureSiteSiteCookies)
+        app.config.middleware.insert_after(Rack::Runtime, Rack::SecureSiteSiteCookies)
       end
     end
   end

--- a/secure_samesite_cookies.gemspec
+++ b/secure_samesite_cookies.gemspec
@@ -14,7 +14,7 @@ Gem::Specification.new do |spec|
   spec.homepage      = "https://github.com/concord-consortium/secure-samesite-cookies"
   spec.license       = "MIT"
 
-  spec.add_dependency "rack", "~> 1.4.7"
+  spec.add_dependency "rack", ">= 1.4.7"
 
   if spec.respond_to?(:metadata)
     # Prevent pushing this gem to RubyGems.org by using fake host url


### PR DESCRIPTION
The `Rack::Runtime` middlware is common to rigse, lara and document-store and is before the rack middlware outputs cookies.  The rack dependency is set to `>= 1.4.7` as rigse and lara use 1.4.7 but the document-store uses 1.6.10.