### PR TITLE
Changed to not add samesite on non-secure cookies

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,6 +3,7 @@ FROM concordconsortium/docker-rails-base-private:ruby-2.3.7-rails-3.2.22.13
 ENV APP_HOME /secure_samesite_cookies
 
 RUN mkdir $APP_HOME
+COPY . $APP_HOME/
 WORKDIR $APP_HOME
 
-ADD . $APP_HOME
+RUN bundle install

--- a/lib/rack/secure_samesite_cookies.rb
+++ b/lib/rack/secure_samesite_cookies.rb
@@ -19,8 +19,8 @@ module Rack
         # set secure flag if this is https request
         add_secure = Rack::Request.new(env).ssl?
 
-        # add SiteSite attribute only for Chrome for now
-        add_same_site = !!(env["HTTP_USER_AGENT"] =~ /\schrome\//i)
+        # add SiteSite attribute only for Chrome for now when in secure mode
+        add_same_site = add_secure && !!(env["HTTP_USER_AGENT"] =~ /\schrome\//i)
 
         cookies.each do |cookie|
           # can't use .present? as we aren't running in rails in tests

--- a/lib/rack/secure_samesite_cookies/version.rb
+++ b/lib/rack/secure_samesite_cookies/version.rb
@@ -1,5 +1,5 @@
 module Rack
   class SecureSamesiteCookies
-    VERSION = "0.1.0"
+    VERSION = "1.0.1"
   end
 end

--- a/spec/lib/rack/secure_samesite_cookies_spec.rb
+++ b/spec/lib/rack/secure_samesite_cookies_spec.rb
@@ -35,14 +35,14 @@ describe "Rack::SecureSiteSiteCookies" do
   end
 
   describe "with non-ssl requests and chrome user-agents" do
-    it "does not add secure attribute but adds samesite attribute" do
+    it "does not add secure attribute or samesite attribute" do
       header "User-Agent", chrome_ua
       get "/"
-      assert_equal cookie_from_response(), "#{raw_cookie}; SameSite=None"
+      assert_equal cookie_from_response(), raw_cookie
     end
   end
 
-  describe "with ssl requests and non-chrome user-agents" do
+  describe "with ssl requests and chrome user-agents" do
     it "adds secure attribute and samesite attribute" do
       header "User-Agent", chrome_ua
       get "/", {}, {'HTTPS' => 'on'}


### PR DESCRIPTION
Chrome blocks cookies that set SameSite on non-secure cookies